### PR TITLE
Add support for multiple statistics besides "sum"

### DIFF
--- a/cw2graphite.js
+++ b/cw2graphite.js
@@ -60,7 +60,9 @@ function printMetric(metric, get_start_time, get_end_time) {
                 return n.Timestamp.getTime();
             });
             for (var point in sorted_data) {
-                console.log("%s %s %s", getMetricStatistics_param.Namespace.replace("/", ".") + dimension_prefix + "." + getMetricStatistics_param.MetricName, sorted_data[point].Sum, parseInt(new Date(sorted_data[point].Timestamp).getTime() / 1000.0));
+                for (var statistic in getMetricStatistics_param.Statistics) {
+                    console.log("%s %s %s", getMetricStatistics_param.Namespace.replace("/", ".") + dimension_prefix + "." + getMetricStatistics_param.MetricName, statistic, parseInt(new Date(sorted_data[point].Timestamp).getTime() / 1000.0));
+                }
             }
         }
     });


### PR DESCRIPTION
Put together a solution with @praymann that resolves #12 

AWS Cloudwatch uses and supports multiple statistics including sum, average, minimum, maximum, etc. but cw2graphite appears to be hard-coded for "sum" currently. This change adds support for multiple Statistics for each data point as set in the metrics config.